### PR TITLE
Support variables in <esi:vars>

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,7 +341,7 @@ function ESIListener(context) {
       let variableValue = context.assigns[variableName] || "";
       const textToReplace = match[0];
 
-      if (propertyName) {
+      if (variableValue && propertyName) {
         variableValue = variableValue[propertyName] || "";
       }
       returnText = returnText.replace(textToReplace, variableValue);

--- a/index.js
+++ b/index.js
@@ -342,7 +342,7 @@ function ESIListener(context) {
       const textToReplace = match[0];
 
       if (propertyName) {
-        variableValue = variableValue[propertyName];
+        variableValue = variableValue[propertyName] || "";
       }
       returnText = returnText.replace(textToReplace, variableValue);
     }

--- a/index.js
+++ b/index.js
@@ -312,7 +312,31 @@ function ESIListener(context) {
 
     text = text.replace(/\\["]/g, "\"");
 
+    if (context.inEsiStatementProcessingContext) {
+      text = replaceVariablesWithValues(text);
+    }
+
     return text;
+  }
+
+  function replaceVariablesWithValues(text) {
+    //Replace strings such as `$(myVariable)` with a value
+
+    const esiVariableRegex = /\$\(([^)]+)\)/g;
+
+    let match;
+    let returnText = text;
+    while ((match = esiVariableRegex.exec(text)) != null) {
+      const variableName = match[1];
+      const variableValue = context.assigns[variableName] || "";
+      const textToReplace = match[0];
+      if (!variableValue) {
+        /*eslint-disable no-console*/
+        console.warn("Warning. Your ESI code tries to output the variable", variableName, "but it lacks a defined value");
+      }
+      returnText = returnText.replace(textToReplace, variableValue);
+    }
+    return returnText;
   }
 
   function onclosetag(tagname, next) {

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -1425,10 +1425,26 @@ describe("local ESI", () => {
       }, done);
     });
 
-    it("should replace $(myVariable) with an empty string, inside <esi:vars>", (done) => {
+    it("should replace undefined variables with empty strings (inside <esi:vars>)", (done) => {
       const markup = "<esi:vars>This is what an undefined variable looks like: $(myVariable)</esi:vars>";
       const expectedMarkup = "This is what an undefined variable looks like: ";
       localEsi(markup, {}, {
+        send(body) {
+          expect(body).to.equal(expectedMarkup);
+          done();
+        }
+      }, done);
+    });
+
+    it("should be able to replace $(HTTP_COOKIE{'cookie1'}) with the cookie's value inside <esi:var>", (done) => {
+      const markup = `
+        <esi:vars>
+        $(HTTP_COOKIE{'cookie1'})
+        </esi:vars>
+        `.replace(/^\s+|\n/gm, "");
+
+      const expectedMarkup = "Kaka nummer ett";
+      localEsi(markup, { cookies: { cookie1: "Kaka nummer ett" } }, {
         send(body) {
           expect(body).to.equal(expectedMarkup);
           done();

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -570,6 +570,36 @@ describe("local ESI", () => {
       }, done);
     });
 
+    it("should be able to parse variables in the src attribute of esi:include", (done) => {
+      /*eslint-disable quotes */
+      const markup = `<esi:assign name="siteName" value="some-server" /><esi:include src="https://$(siteName)/bazinga/"></esi:include>`;
+
+      nock("https://some-server")
+        .get("/bazinga/")
+        .reply(200, "respons från https://some-server/bazinga/");
+
+      nock("http://localhost:4567")
+        .get("/mystuff/")
+        .reply(200, "Hejsan");
+
+      localEsi(markup, {
+        socket: {
+          server: {
+            address() {
+              return {
+                port: 4567
+              };
+            }
+          }
+        }
+      }, {
+        send(body) {
+          expect(body).to.equal("respons från https://some-server/bazinga/");
+          done();
+        }
+      }, done);
+    });
+
     it("should handle errors when esi:including using esi:try", (done) => {
       let markup = "<esi:try>";
       markup += "<esi:attempt>";

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -1390,4 +1390,50 @@ describe("local ESI", () => {
       }, done);
     });
   });
+
+  describe("esi:vars", () => {
+    it("should be able to replace a variable with it's value when inside <esi:vars>", (done) => {
+      const markup = "<esi:assign name=\"myVariable\" value=\"Hello\"/><esi:vars>$(myVariable)</esi:vars>";
+      const expectedMarkup = "Hello";
+      localEsi(markup, {}, {
+        send(body) {
+          expect(body).to.equal(expectedMarkup);
+          done();
+        }
+      }, done);
+    });
+
+    it("should be able to output the value of multiple variables when inside <esi:vars>", (done) => {
+      const markup = "<esi:assign name=\"myVariable\" value=\"Hello\"/><esi:assign name=\"anotherVariable\" value=\"Goodbye\"/><esi:vars>$(myVariable) $(anotherVariable)</esi:vars>";
+      const expectedMarkup = "Hello Goodbye";
+      localEsi(markup, {}, {
+        send(body) {
+          expect(body).to.equal(expectedMarkup);
+          done();
+        }
+      }, done);
+    });
+
+    it("should not touch a piece of text like `$(string)` when it's outside of <esi:vars>", (done) => {
+      const markup = "<p>$(string)</p>";
+      const expectedMarkup = "<p>$(string)</p>";
+      localEsi(markup, {}, {
+        send(body) {
+          expect(body).to.equal(expectedMarkup);
+          done();
+        }
+      }, done);
+    });
+
+    it("should replace $(myVariable) with an empty string, inside <esi:vars>", (done) => {
+      const markup = "<esi:vars>This is what an undefined variable looks like: $(myVariable)</esi:vars>";
+      const expectedMarkup = "This is what an undefined variable looks like: ";
+      localEsi(markup, {}, {
+        send(body) {
+          expect(body).to.equal(expectedMarkup);
+          done();
+        }
+      }, done);
+    });
+  });
 });


### PR DESCRIPTION
Support variables in `<esi:vars>`

Such as `<esi:assign name="myVariable" value="Hello"/><esi:vars>$(myVariable)</esi:vars>` outputting "Hello" instead of "$(myVariable)"