### PR TITLE
fix so regex characters don't break expression parser

### DIFF
--- a/lib/esiExpressionParser.js
+++ b/lib/esiExpressionParser.js
@@ -6,6 +6,25 @@ module.exports = function esiExpressionParser(str) {
   if (nonsenseParentheseseMatch && wellFormedParentheses(nonsenseParentheseseMatch[1])) {
     str = nonsenseParentheseseMatch[1];
   }
+
+  const regexComparisonMatch = str.match(/(.+?)(matches_i|matches)(.+)/);
+  if (regexComparisonMatch) {
+    return {
+      type: "BinaryExpression",
+      operator: regexComparisonMatch[2],
+      left: esiExpressionParser(regexComparisonMatch[1]),
+      right: esiExpressionParser(regexComparisonMatch[3])
+    };
+  }
+
+  const escapedStringLiteralMatch = str.match(/^'''([^']+?)'''/);
+  if (escapedStringLiteralMatch) {
+    return {
+      type: "Literal",
+      value: escapedStringLiteralMatch[1]
+    };
+  }
+
   const binaryLogicalMatch = str.match(/(.+?)\s*(&{1,2}|\|{1,2})\s*(.+)/);
   if (binaryLogicalMatch) {
     return {
@@ -16,7 +35,7 @@ module.exports = function esiExpressionParser(str) {
     };
   }
 
-  const binaryComparisonMatch = str.match(/(.+?)(==|>=|<=|<|>|has_i|has|matches_i|matches)(.+)/);
+  const binaryComparisonMatch = str.match(/(.+?)(==|>=|<=|<|>|has_i|has)(.+)/);
   if (binaryComparisonMatch) {
     return {
       type: "BinaryExpression",
@@ -66,14 +85,6 @@ module.exports = function esiExpressionParser(str) {
     return {
       type: "Literal",
       value: stringLiteralMatch[1]
-    };
-  }
-
-  const escapedStringLiteralMatch = str.match(/^'''([^']+?)'''/);
-  if (escapedStringLiteralMatch) {
-    return {
-      type: "Literal",
-      value: escapedStringLiteralMatch[1]
     };
   }
 

--- a/test/esiExpressionParserTest.js
+++ b/test/esiExpressionParserTest.js
@@ -511,4 +511,20 @@ describe("esiExpressionParser", () => {
     expect(result).to.have.property("type", "Literal");
     expect(result).to.have.property("value").that.eql("jan.bananberg@test.com");
   });
+
+  it("handles binary expression where one expression is a regular expression", () => {
+    const input = "$(HTTP_REFERER) matches '''(google|yahoo|bing|yandex)\\.\\d+$'''";
+    const result = esiExpressionParser(input);
+
+    expect(result).to.have.property("type", "BinaryExpression");
+    expect(result).to.have.property("left").that.eql({
+      type: "Identifier",
+      name: "HTTP_REFERER"
+    });
+    expect(result).to.have.property("operator").that.eql("matches");
+    expect(result).to.have.property("right").that.eql({
+      type: "Literal",
+      value: "(google|yahoo|bing|yandex)\\.\\d+$"
+    });
+  });
 });


### PR DESCRIPTION
Tests pass. Also did manual test by deploying Solveig with a real life example (same as in added test) to http://www-livedata.expressen.se in order to see how Akamai handles that particular expression. Same expression also works when running Solveig locally with with these changes in local-esi linked.