### PR TITLE
Prevent ESI processing of JS code in ESI-tags

### DIFF
--- a/lib/ESIListener.js
+++ b/lib/ESIListener.js
@@ -300,11 +300,11 @@ module.exports = function ESIListener(context) {
         newText += char;
       }
 
-      if (char === "(") {
+      if (inExpression && char === "(") {
         openParentheses++;
       }
 
-      if (char === ")") {
+      if (inExpression && char === ")") {
         openParentheses--;
         if (openParentheses === 0) {
           inExpression = false;

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -17,6 +17,42 @@ describe("local ESI", () => {
     }, done);
   });
 
+  it("should not touch JS in script-tag inside <esi:choose>", (done) => {
+    const scriptTag = `<script>!function(){"use strict";window.foobar=function(e){var n=document.getElementsByClassName(e)[0];}();</script>`; //eslint-disable-line quotes
+
+    const markup = `<!DOCTYPE html><html><head><title>This is a title</title></head><body>Test: <b>Testsson</b>
+    <esi:choose>
+      <esi:when test="1 == 1">
+        ${scriptTag}
+      </esi:when>
+    </esi:choose>
+    </body></html>`;
+
+    localEsi(markup, {}, {
+      send(body) {
+        expect(body).to.contain(scriptTag);
+        done();
+      }
+    }, done);
+  });
+
+  it("should not touch JS in script-tag inside <esi:vars>", (done) => {
+    const scriptTag = `<script>!function(){"use strict";window.foobar=function(e){var n=document.getElementsByClassName(e)[0];}();</script>`; //eslint-disable-line quotes
+
+    const markup = `<!DOCTYPE html><html><head><title>This is a title</title></head><body>Test: <b>Testsson</b>
+    <esi:vars>
+      ${scriptTag}
+    </esi:vars>
+    </body></html>`;
+
+    localEsi(markup, {}, {
+      send(body) {
+        expect(body).to.contain(scriptTag);
+        done();
+      }
+    }, done);
+  });
+
   describe("esi:choose", () => {
     it("should render the otherwise statement of an esi:choose when not matching our specific test", (done) => {
       let markup = "<esi:choose>";


### PR DESCRIPTION
At the moment, `evaluateExpression` on line `311` will execute as soon as there's a closing parenthesis in a text inside an ESI tag.

I tried including a `<script>` with a javascript function inside an ESI-choose and the ESI parser completely mangled the javascript code by adding `false` after every closing parenthesis.

This PR ensures that `evaluateExpression` on line `311` only runs when `inExpression` is true.

---

Added test cases to ensure the parser does not touch javascript in `<esi:vars>` or `<esi:choose>` 

Unless there is a `$` character involved, the text should remain untouched and not be processed as an ESI expression