### PR TITLE
Trailing slash for included path in URL not be a requirement

### DIFF
--- a/lib/ESIListener.js
+++ b/lib/ESIListener.js
@@ -175,9 +175,6 @@ module.exports = function ESIListener(context) {
       source = context.assigns[source.substring(2, source.length - 1)];
     }
 
-    if (!url.parse(source).pathname.endsWith("/")) {
-      return fetchCallback(new Error("Included URL's path name must end with /"));
-    }
     for (const key in context.assigns) {
       if (typeof context.assigns[key] === "string") {
         source = source.replace(`$(${key})`, context.assigns[key]);


### PR DESCRIPTION
There's no requirements that you must use trailing slashes when including URLs in ESI, so I don't understand why it throws an exception for paths without trailing slash.

We have several cases without trailing slashes running in production in bang.

In fact some of the services we call via ESI do not even support trailing slash. So at the moment we cannot implement local-esi in our project because of this arbitrary trailing slash requirement

Example code from https://github.com/BonnierNews/bang/blob/master/views/layouts/base.njk
```
   <esi:try>
      <esi:attempt>
        <esi:eval src="{{ meta.bangPersonalizedUrl }}/entitled" dca="none" maxwait="1000" no-store="on" setheader="True-Client-IP:$(REMOTE_ADDR)" />
      </esi:attempt>
    </esi:try>
```


---

I've kept the two test-cases which were previously used to ensure an exception was thrown.
Perhaps they're a bit superflous now and can be removed, but I chose to make them do the opposite - ensure that urls without trailing slash also work.