### PR TITLE
Support HTTP_COOKIE and url_encode in esi:include

### DIFF
--- a/lib/ESIListener.js
+++ b/lib/ESIListener.js
@@ -171,8 +171,8 @@ module.exports = function ESIListener(context) {
 
     let source = attribs.src;
 
-    if (source.startsWith("$(") && source.endsWith(")")) { //src is a variable
-      source = context.assigns[source.substring(2, source.length - 1)];
+    if (source.indexOf("$(") > -1 && source.indexOf(")") > -1) {
+      source = handleProcessingInstructions(source);
     }
 
     if (!url.parse(source).pathname.endsWith("/")) {

--- a/lib/evaluateExpression.js
+++ b/lib/evaluateExpression.js
@@ -32,6 +32,14 @@ module.exports = function evaluateExpression(test, context) {
       return Buffer.from(string, "utf8").toString("base64");
     },
     // eslint-disable-next-line camelcase
+    url_encode([arg]) {
+      const string = getFunc(arg.type)(arg);
+      if (!string) {
+        return "";
+      }
+      return encodeURIComponent(string);
+    },
+    // eslint-disable-next-line camelcase
     add_header([name, value]) {
       context.res.set(getFunc(name.type)(name), getFunc(value.type)(value));
     },

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -1082,7 +1082,7 @@ describe("local ESI", () => {
       }, done);
     });
 
-    it("should support esi:include when url is from variable", (done) => {
+    it("should support esi:include when entire URL is a variable", (done) => {
       let markup = "<esi:assign name=\"daurl\" value=\"http://mystuff.com/\"/>";
       markup += "<esi:include src=\"$(daurl)\" dca=\"esi\"/><p>efter</p>";
 
@@ -1109,34 +1109,61 @@ describe("local ESI", () => {
         }
       }, done);
     });
-  });
 
-  it("should support esi:include when url is from variable", (done) => {
-    let markup = "<esi:assign name=\"host\" value=\"mystuff.com\"/>";
-    markup += "<esi:include src=\"http://$(host)/path/\" dca=\"esi\"/><p>efter</p>";
+    it("should support esi:include when URL contains a variable", (done) => {
+      let markup = "<esi:assign name=\"host\" value=\"mystuff.com\"/>";
+      markup += "<esi:include src=\"http://$(host)/path/\" dca=\"esi\"/><p>efter</p>";
 
-    nock("http://mystuff.com", {
-      reqheaders: { host: "mystuff.com"}
-    })
-      .get("/path/")
-      .reply(200, "<p><esi:vars>hej</esi:vars></p>");
+      nock("http://mystuff.com", {
+        reqheaders: { host: "mystuff.com"}
+      })
+        .get("/path/")
+        .reply(200, "<p><esi:vars>hej</esi:vars></p>");
 
-    localEsi(markup, {
-      socket: {
-        server: {
-          address() {
-            return {
-              port: 1234
-            };
+      localEsi(markup, {
+        socket: {
+          server: {
+            address() {
+              return {
+                port: 1234
+              };
+            }
           }
         }
-      }
-    }, {
-      send(body) {
-        expect(body).to.equal("<p>hej</p><p>efter</p>");
-        done();
-      }
-    }, done);
+      }, {
+        send(body) {
+          expect(body).to.equal("<p>hej</p><p>efter</p>");
+          done();
+        }
+      }, done);
+    });
+
+    it("should support esi:include when URL contains a HTTP_COOKIE", (done) => {
+      const markup = "<esi:include src=\"/foo$(HTTP_COOKIE{'MyCookie'})/\" dca=\"esi\"/><p>efter</p>";
+
+      nock("http://localhost:1234")
+        .get("/foobar/")
+        .reply(200, "<p><esi:vars>hej</esi:vars></p>");
+
+      localEsi(markup, {
+        cookies: { MyCookie: "bar" },
+        socket: {
+          server: {
+            address() {
+              return {
+                port: 1234
+              };
+            }
+          }
+        }
+      }, {
+        send(body) {
+          expect(body).to.equal("<p>hej</p><p>efter</p>");
+          done();
+        }
+      }, done);
+    });
+
   });
 
   describe("esi:choose", () => {


### PR DESCRIPTION
Added a new test-case for this scenario, which I'm currently using in production and need local-esi to support:
`<esi:include src="/blahonga/weather?locationId=$(HTTP_COOKIE{'weatherLocation'})" onerror="continue"></esi:include>`


At the moment local-esi can only parse the src as a variable if the whole thing is a avariable - it cannot handle a partial string concatenated with a variable. Also it only looks for variables directly under `context.assigns` - so it doesn't support HTTP_COOKIE


With this PR, the source will be processed via `handleProcessingInstructions`, so all kinds of variable parsing will be supported.

----

Once I added proper parsing of sources I noticed that a differet test started throwing the error `$url_encode is not implemented`

```
it("should handle include source query parameters", (done) => {
      let markup = "<esi:assign name=\"user_email\" value=\"sammy_g@test.com\"/>";
      markup += "<esi:include src=\"/mystuff/?a=b&user=$url_encode($(user_email))\" dca=\"esi\"/>";
```

I don't know how this test even worked to begin with, cause the error is correct - url_encode was not supported

I implemented it by simply making it run `encodeURIComponent` and that made the test pass