### PR TITLE
Setting encoding on reader stream

### DIFF
--- a/lib/transformHtml.js
+++ b/lib/transformHtml.js
@@ -55,6 +55,7 @@ function convert(buf, chunkSize) {
   buf = Buffer.from(buf, "utf8");
 
   const reader = new Readable();
+  reader.setEncoding("utf8");
   const hwm = reader._readableState.highWaterMark;
 
   if (!chunkSize || chunkSize < 1 || chunkSize > hwm) {

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -17,6 +17,16 @@ describe("local ESI", () => {
     }, done);
   });
 
+  it("should not touch multi-byte characters", (done) => {
+    const markup = `<!DOCTYPE html><html><head><title>This is a title</title></head><body>${Array(1000).fill("Töst: <b>Töst</b>").join("")}</body></html>`;
+    localEsi(markup, {}, {
+      send(body) {
+        expect(body).to.equal(markup);
+        done();
+      }
+    }, done);
+  });
+
   it("should not touch JS in script-tag inside <esi:choose>", (done) => {
     const scriptTag = `<script>!function(){"use strict";window.foobar=function(e){var n=document.getElementsByClassName(e)[0];}();</script>`; //eslint-disable-line quotes
 

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -18,7 +18,10 @@ describe("local ESI", () => {
   });
 
   it("should not touch multi-byte characters", (done) => {
-    const markup = `<!DOCTYPE html><html><head><title>This is a title</title></head><body>${Array(1000).fill("Töst: <b>Töst</b>").join("")}</body></html>`;
+    const prefix = "<!DOCTYPE html><html><head><title>This is a title</title></head><body>";
+    const suffix = "</body></html>";
+    const characters = Array(9817).fill("Töst").join("");
+    const markup = prefix + characters + suffix;
     localEsi(markup, {}, {
       send(body) {
         expect(body).to.equal(markup);


### PR DESCRIPTION
This is to prevent buffer from running out when reading multi-byte characters.

See more information here: 
https://nodejs.org/docs/latest-v10.x/api/stream.html#stream_new_stream_readable_options
https://nodejs.org/docs/latest-v10.x/api/stream.html#stream_highwatermark_discrepancy_after_calling_readable_setencoding

This causes multi-byte characters (like ö) in `utf8` to sometimes not be read correctly as the buffer runs out before reaching them. 
Writing a test case for this is a bit wonky as it's hard to determine exactly when the buffer runs out. I tried to calculate this more exactly but knowing how many bits is contained in a unicode character is anyone's guess 🤷‍♂ 