### PR TITLE
Handle illegal characters like Akamai's ESI parser

### DIFF
--- a/lib/ESIListener.js
+++ b/lib/ESIListener.js
@@ -254,7 +254,7 @@ module.exports = function ESIListener(context) {
     if (context.inEsiStatementProcessingContext && !current.plainText) {
       try {
         return writeToResult(() => {
-          return ensureNoIllegalCharacters(handleProcessingInstructions(text));
+          return handleProcessingInstructions(ensureNoIllegalCharacters(text));
         }, next); //handleProcessingInstructions may cause an (expected) error and we're not sure writeToResult will actually write so we pass a function that it can call if it should write
       } catch (err) {
         return next(err);

--- a/lib/ESIListener.js
+++ b/lib/ESIListener.js
@@ -250,15 +250,44 @@ module.exports = function ESIListener(context) {
 
   function ontext(text, next) {
     const [current = {}] = context.tags.slice(-1);
+
     if (context.inEsiStatementProcessingContext && !current.plainText) {
       try {
-        return writeToResult(handleProcessingInstructions.bind(null, text), next); //handleProcessingInstructions may cause an (expected) error and we're not sure writeToResult will actually write so we pass a function that it can call if it should write
+        return writeToResult(() => {
+          return ensureNoIllegalCharacters(handleProcessingInstructions(text));
+        }, next); //handleProcessingInstructions may cause an (expected) error and we're not sure writeToResult will actually write so we pass a function that it can call if it should write
       } catch (err) {
         return next(err);
       }
     }
 
-    writeToResult(text, next);
+    try {
+      return writeToResult(ensureNoIllegalCharacters(text, current.plainText), next);
+    } catch (err) {
+      return next(err);
+    }
+  }
+
+  function ensureNoIllegalCharacters(text, inPlainText) {
+    if (inPlainText) return text;
+
+    // matches
+    // - weird quotes
+    // - dollar signs not part of an esi expression
+    const pattern = /(“|”|\$(?!\w*?\())/g;
+    let match;
+
+    while ((match = pattern.exec(text))) {
+      const {"1": character, index} = match;
+      if (text.charAt(index - 1) === "\\") continue;
+
+      const excerptStart = Math.max(index - 30, 0);
+      const excerpt = text.substr(excerptStart, 60);
+
+      throw new Error(`Illegal character "${character}" in "${excerpt}"`);
+    }
+
+    return text;
   }
 
   function handleProcessingInstructions(text) {


### PR DESCRIPTION
By crashing on unexpected illegal characters we can test for properly escaped content