### PR TITLE
Allow passing res.send from calling context

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,28 @@ module.exports = (req, res, next) => {
   });
 };
 ```
+
+# Another example Express route:
+
+Apply local-esi to all HTML output
+
+```javascript
+"use strict";
+
+app.use((req, res, next) => {
+  const _send = res.send;
+
+  res.send = function Send(body) {
+    const resHeaders = res.getHeaders();
+    const resContentType = resHeaders && resHeaders["content-type"];
+    if (resContentType && resContentType.includes("text/html")) {
+      _send.call(this, body);
+    } else {
+      const options = { send: _send, sendContext: this };
+      localEsi(body, req, res, next, options);
+    }
+  };
+
+  next();
+})
+```

--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 "use strict";
 
-
 const transformHtml = require("./lib/transformHtml");
 const ESIListener = require("./lib/ESIListener");
 const ListenerContext = require("./lib/ListenerContext");
 
 
-function localEsi(html, req, res, next) {
+function localEsi(html, req, res, next, options = {}) {
   const context = ListenerContext(req, res);
   const listener = ESIListener(context);
   transformHtml(html, listener, (err, parsed) => {
@@ -14,10 +13,11 @@ function localEsi(html, req, res, next) {
     if (context.redirected) {
       return;
     }
+    const useExternalSendFn = options && options.sendContext && options.send;
     if (context.replacement) {
-      return res.send(context.replacement);
+      return useExternalSendFn ? options.send.call(options.sendContext, context.replacement) : res.send(context.replacement);
     }
-    res.send(parsed);
+    return useExternalSendFn ? options.send.call(options.sendContext, parsed) : res.send(parsed);
   });
 }
 


### PR DESCRIPTION
I want ESI-parse _all_ HTML output from my application by adding middleware that hooks into `res.send` and passes all html content to `local-esi`.

This doesn't work with the current implementation though.

To make it work with `res.send` we must pass that function and it's context from the app into the localEsi module ( [An example of this approach](https://github.com/expressjs/express/issues/1583#issuecomment-16540716 ) ) 

