### PR TITLE
Support http_time

### DIFF
--- a/lib/evaluateExpression.js
+++ b/lib/evaluateExpression.js
@@ -80,6 +80,12 @@ module.exports = function evaluateExpression(test, context) {
     time() {
       return Math.round(Date.now() / 1000);
     },
+    // eslint-disable-next-line camelcase
+    http_time([seconds]) {
+      const secondsInt = parseInt(getFunc(seconds.type)(seconds));
+      const now = new Date(secondsInt * 1000);
+      return now.toUTCString();
+    },
     CallExpression(node) {
       return getFunc(node.callee.name)(node.arguments);
     },

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -2108,6 +2108,24 @@ describe("local ESI", () => {
     });
   });
 
+  describe("$http_time", () => {
+    it("supports $http_time", (done) => {
+      const markup = `
+        <esi:assign name="now" value="$http_time(995319416)" />
+        <esi:vars>
+          <p>$(now)</p>
+        </esi:vars>
+      `.replace(/^\s+|\n/gm, "");
+
+      localEsi(markup, { }, {
+        send(body) {
+          expect(body).to.equal("<p>Mon, 16 Jul 2001 21:36:56 GMT</p>");
+          done();
+        }
+      }, done);
+    });
+  });
+
   describe("has and has_i operator", () => {
     it("supports has operator", (done) => {
       const markup = `


### PR DESCRIPTION
# support `http_time` 

Page 79 of the [ESI docs](https://www.akamai.com/cn/zh/multimedia/documents/technical-publication/akamai-esi-developers-guide-technical-publication.pdf) describes http_time as:

> "$http_time() takes a single parameter, a integer representing Unix epoch time—that
is, a number of seconds since Jan 1, 1970. This function returns a string formatted
according to RFC 1123, the official method for representing time in HTTP. For
example, $http_time(995319416) returns Mon, 16 Jul 2001 14:36:56 GMT.
OR, $http_time($time()) would return the current time in the same format. A
typical use of this construction is contained in the preceding example on the
add_header() function."


## PS 
 Note that the docs are slightly incorrect - the output time of the example is supposed to be `21:36:56` instead of `14:36:56` 😆 

I ran the test through Akamai's own test server ( https://github.com/akamai/esi-test-server-docker ) and found that it does output `21:36:56` so that must be more correct than the docs (which haven't been updated since 2005)

![image](https://user-images.githubusercontent.com/3415677/65437827-cb268900-de24-11e9-909c-6438501c4741.png)

And I've included the correct value in our test case