### PR TITLE
Allow quotes in esi:choose. The only forbidden character should be $.

### DIFF
--- a/lib/ESIListener.js
+++ b/lib/ESIListener.js
@@ -270,9 +270,8 @@ module.exports = function ESIListener(context) {
 
   function ensureNoIllegalCharacters(text) {
     // matches
-    // - weird quotes
     // - dollar signs not part of an esi expression
-    const pattern = /(“|”|\$(?!\w*?\())/g;
+    const pattern = /(\$(?!\w*?\())/g;
     let match;
 
     while ((match = pattern.exec(text))) {

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -1461,12 +1461,25 @@ describe("local ESI", () => {
     });
   });
 
+  it("supports weird quotes like “ and ” inside esi:choose", (done) => {
+    const innerText = "Here's a quote by Wayne Gretzky: “You miss 100% of the shots you don't take“. <br> Here's a quote by Homer Simpson: ”do'h”. This text should be valid in any ESI context.";
+    const markup = `<esi:choose><esi:when test="1==1">${innerText}</esi:when></esi:choose>`;
+
+    localEsi(markup, { }, {
+      send(body) {
+        expect(body).to.equal(innerText);
+        done();
+      }
+    }, done);
+  });
+
+
   describe("illegal characters", () => {
-    [
-      "$",
-      "“",
-      "”",
-    ].forEach((character) => {
+    const illegalCharacters = [
+      "$"
+    ];
+
+    illegalCharacters.forEach((character) => {
       it(`doesn't crash on illegal "${character}" character outside of esi context`, (done) => {
         const html = `<p>This text contains expected ${character} character</p>`;
 
@@ -1491,7 +1504,7 @@ describe("local ESI", () => {
           </esi:choose>`.replace(/^\s+|\n/gm, "");
 
         localEsi(markup, {}, {send: unexpectedCallback.bind(null, done, null)}, (err) => {
-          expect(err, "no error").to.exist;
+          expect(err).to.exist;
           expect(err.message, "wrong error").to.include("Illegal character");
           done();
         });


### PR DESCRIPTION
There's nothing wrong with having quotes inside an ESI context. 

In this PR we said that quotes are forbidden inside all esi-tags except esi-text https://github.com/BonnierNews/local-esi/pull/20/files

But quotes are prerfectly valid, even inside `<esi:when>` tags. 

I've tested this using Akamai's local esi test tool: https://github.com/akamai/esi-test-server-docker 
![image](https://user-images.githubusercontent.com/3415677/65497396-77ff1580-deba-11e9-8be3-c3ab607772fd.png)

$ is the only character which can cause a 500 in `<esi:when>`

![image](https://user-images.githubusercontent.com/3415677/65497688-ea6ff580-deba-11e9-8a0a-0e1e328f4512.png)

------------

## Side note:

In the test-case where we expect to get an error if we use a `$` inside an esi:choose, we previously had this code
```
expect(err, "no error").to.exist;
```
I don't see the point of the "no error" text here.

So I changed it to
```
expect(err).to.exist;
```

Please correct me if this was incorrect
