### PR TITLE
Test-case: Access properties from Dictionary variable

### DIFF
--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -1631,6 +1631,27 @@ describe("local ESI", () => {
       }, done);
     });
 
+    it("can access values from a Dictionary variable", (done) => {
+      const markup = `
+        <esi:assign name="pizzaIngredients" value="{'cheese': 'true', 'avocado': 'false'}" />
+        <esi:assign name="hasAvocado" value="$(pizzaIngredients{avocado})" />
+        <esi:vars>
+          <p>Does a pizza have avocado: $(hasAvocado)</p>
+        </esi:vars>
+        `.replace(/^\s+|\n/gm, "");
+
+      const expectedMarkup = `
+        <p>Does a pizza have avocado: false</p>
+      `.replace(/^\s+|\n/gm, "");
+
+      localEsi(markup, {}, {
+        send(body) {
+          expect(body).to.equal(expectedMarkup);
+          done();
+        }
+      }, done);
+    });
+
     it("preserves state between iterations", (done) => {
       const markup = `
         <ul>

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -1631,13 +1631,11 @@ describe("local ESI", () => {
       }, done);
     });
 
-    it("can access values from a Dictionary variable", (done) => {
+    it("can access values from a Dictionary variable (via single-quoted key)", (done) => {
+      // Note: ESI supports variable access using both with or without single-quotes, but local-esi requires the single-quotes
       const markup = `
         <esi:assign name="pizzaIngredients" value="{'cheese': 'true', 'avocado': 'false'}" />
-        <esi:assign name="hasAvocado" value="$(pizzaIngredients{avocado})" />
-        <esi:vars>
-          <p>Does a pizza have avocado: $(hasAvocado)</p>
-        </esi:vars>
+        <p><esi:vars>Does a pizza have avocado: $(pizzaIngredients{'avocado'})</esi:vars></p>
         `.replace(/^\s+|\n/gm, "");
 
       const expectedMarkup = `


### PR DESCRIPTION
There is no support for Dictionaries except for when used as `esi:foreach collection` 

My test scenario...
```
        <esi:assign name="pizzaIngredients" value="{'cheese': 'true', 'avocado': 'false'}" />
        <esi:assign name="hasAvocado" value="$(pizzaIngredients{avocado})" />
        <esi:vars>
          <p>Does a pizza have avocado: $(hasAvocado)</p>
        </esi:vars>
```
..results in unparsed code:
```
<p>hasCheese: '$(pizzaIngredients{cheese})</p>
``` 

## The problem
The issue is that lexer.js can't handle property accessors such as: `$(pizzaIngredients{avocado})` 

`lexer.js` will abort with "Unknown keyword"!  
```
if (keywords.indexOf(token.cargo) === -1) {
        token.abort("Unknown keyword", token.cargo);
 }
```
At this point `token.cargo` would be `avocado` so it would throw `Unknown keyword 'avocado'`

_The only known keywords are `[matches, matches_i, has, has_i]`_

## Possible solution ⚒️  

I've got a hacky solution which works for my particular test case
https://github.com/BonnierNews/local-esi/compare/master...niklasHagner:dictionary-hack?expand=1

Basicall: removes `token.abort("Unknown keyword", token.cargo)` and assumes unknown tokens are attempts to access a property.