### PR TITLE
Fix problems with optimized HTML from Marko

### DIFF
--- a/lib/markup.js
+++ b/lib/markup.js
@@ -46,8 +46,11 @@ function attributesToString(attr) {
     const value = attr[key];
     if (value === "") {
       return `${attributes} ${key}`;
+    } else if (value.indexOf("\"") > -1) {
+      attributes += ` ${key}="${value.replace(/"/g, "&quot;")}"`;
+    } else {
+      attributes += ` ${key}="${value}"`;
     }
-    attributes += ` ${key}="${value}"`;
     return attributes;
   }, "");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/local-esi",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -127,9 +127,8 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atlas-html-stream": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/atlas-html-stream/-/atlas-html-stream-1.2.0.tgz",
-      "integrity": "sha512-jtBouDaA7dfYtpgjEnrW6D+bI+YiGVhHGvXFZiUfq6GiZKs6v8Z+G3qWPqxCn4S+2pwA52CA+0Iao36nQ1GLxg==",
+      "version": "git://github.com/BonnierNews/atlas-html-stream.git#f9a70144ecf76f5b954e42cafac97e76cfac30a8",
+      "from": "git://github.com/BonnierNews/atlas-html-stream.git",
       "requires": {
         "atlas-seq-matcher": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nock": "^11.7.2"
   },
   "dependencies": {
-    "atlas-html-stream": "^1.2.0",
+    "atlas-html-stream": "git://github.com/BonnierNews/atlas-html-stream.git",
     "pump": "^3.0.0",
     "pumpify": "^2.0.1",
     "request": "^2.88.0"

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -5,7 +5,7 @@ const nock = require("nock");
 
 describe("local ESI", () => {
   describe("html", () => {
-    it("should not touch regular markup", (done) => {
+    it("should not touch regular markup (notably)", (done) => {
       const markup = `
         <!DOCTYPE html>
         <html>
@@ -14,13 +14,24 @@ describe("local ESI", () => {
           </head>
           <body>
             Test: <b>Testsson</b>
+            <a href=/some/where/>link</a>
+            <div data-something='{"linkUrl": "/some/where/"}'>component</div>
             <script async src="path/to/script.js"></script>
           </body>
         </html>`.replace(/^\s+|\n/gm, "");
 
       localEsi(markup, {}, {
         send(body) {
-          expect(body).to.equal(markup);
+          const quotedAndEscaped = markup
+            .replace(
+              "/some/where/",
+              "\"/some/where/\""
+            )
+            .replace(
+              "'{\"linkUrl\": \"/some/where/\"}'",
+              "\"{&quot;linkUrl&quot;: &quot;/some/where/&quot;}\"",
+            );
+          expect(body).to.equal(quotedAndEscaped);
           done();
         }
       }, done);


### PR DESCRIPTION
"Quick" fixes for updates in Marko. 

- changes to `htmlWriter` to handle JSON being quoted with single quotes
- using patched fork of `atlas-html-stream` package to handle unquoted attributes

Parser package seems to be dead, though. Actual fix might involve switching parser altogether.

---

Updates make Solveig test suite pass combined with latest version of Marko