### PR TITLE
Fix/escaped quotes in nested json

### DIFF
--- a/lib/markup.js
+++ b/lib/markup.js
@@ -2,6 +2,7 @@
 
 const voidElements = ["area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"];
 const selfClosingElements = ["esi:include", "esi:eval", "esi:assign", "esi:debug", "esi:break"];
+const escapedQuotesInValueRegex = RegExp(/^\\".*\\"$/);
 
 module.exports = {
   chunkToMarkup,
@@ -47,7 +48,7 @@ function attributesToString(attr) {
     if (value === "") {
       return `${attributes} ${key}`;
     }
-    attributes += value.match(/^\\".*\\"$/) !== null ? ` ${key}=${value}` : ` ${key}="${value}"`;
+    attributes += escapedQuotesInValueRegex.test(value) ? ` ${key}=${value}` : ` ${key}="${value}"`;
     return attributes;
   }, "");
 }

--- a/lib/markup.js
+++ b/lib/markup.js
@@ -47,7 +47,7 @@ function attributesToString(attr) {
     if (value === "") {
       return `${attributes} ${key}`;
     }
-    attributes += ` ${key}="${value}"`;
+    attributes += value.match(/^\\".*\\"$/) !== null ? ` ${key}=${value}` : ` ${key}="${value}"`;
     return attributes;
   }, "");
 }

--- a/test/esiTextTest.js
+++ b/test/esiTextTest.js
@@ -48,6 +48,21 @@ describe("esi:text", () => {
     }, done);
   });
 
+  it("escaped quotes in tag attributes inside json property nested in esi:text are kept", (done) => {
+    const markup = `
+      <esi:text>
+        {"items":[{"content":"<div class=\\"div_class_tag\\"><p class=\\"p_class_tag\\">TEXT</p></div>","type":"html-widget"}]}
+      </esi:text>
+      `.replace(/^\s+|\n/gm, "");
+
+    localEsi(markup, { }, {
+      send(body) {
+        expect(JSON.parse(body).items[0].content).to.equal("<div class=\"div_class_tag\"><p class=\"p_class_tag\">TEXT</p></div>");
+        done();
+      }
+    }, done);
+  });
+
   it("remove escaped quotes inside esi context unless esi:text", (done) => {
     const markup = `
       <p>\\"quote 0\\"</p>


### PR DESCRIPTION
html-widgets i json via localESI får jobbigt med redan escapade quotes i attribut


