### PR TITLE
Use res.cookie method when cookie is set via add_header otherwise onl…

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,9 +87,7 @@ function createParser(req) {
 }
 
 function parseCookie(cookieStr) {
-  const attrs = cookieStr.split(";");
-  if (!attrs || attrs.length === 0) return;
-
+  const attrs = (cookieStr || "").split(";");
   const [name, value] = attrs[0].split("=");
   if (!name || !value) return;
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,12 @@ function localEsi(html, req, res, next) {
     res.status(statusCode).send(body === undefined ? "" : body);
   });
   context.on("add_header", (name, value) => {
-    res.set(name, value);
+    if (name.toLowerCase() === "set-cookie") {
+      const cookie = parseCookie(value);
+      res.cookie(cookie.name, cookie.value, cookie.attributes);
+    } else {
+      res.set(name, value);
+    }
   });
   context.once("set_redirect", (statusCode, location) => {
     completed = true;
@@ -77,4 +82,22 @@ function createParser(req) {
   const optimusPrime = createESIParser(listener);
   context.emitter = optimusPrime;
   return optimusPrime;
+}
+
+function parseCookie(cookieStr) {
+  const attrs = cookieStr.split(";");
+  const [name, value] = attrs[0].split("=");
+  const attributes = attrs.reduce((acc, attr, index) => {
+    if (index > 0) {
+      const [attrName, attrValue] = attr.split("=");
+      acc[attrName.trim()] = attrValue && attrValue.trim() || "";
+    }
+    return acc;
+  }, {});
+
+  return {
+    name,
+    value,
+    attributes
+  };
 }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ function localEsi(html, req, res, next) {
   context.on("add_header", (name, value) => {
     if (name.toLowerCase() === "set-cookie") {
       const cookie = parseCookie(value);
-      res.cookie(cookie.name, cookie.value, cookie.attributes);
+      if (cookie) {
+        res.cookie(cookie.name, cookie.value, cookie.attributes);
+      }
     } else {
       res.set(name, value);
     }
@@ -86,7 +88,11 @@ function createParser(req) {
 
 function parseCookie(cookieStr) {
   const attrs = cookieStr.split(";");
+  if (!attrs || attrs.length === 0) return;
+
   const [name, value] = attrs[0].split("=");
+  if (!name || !value) return;
+
   const attributes = attrs.reduce((acc, attr, index) => {
     if (index > 0) {
       const [attrName, attrValue] = attr.split("=");

--- a/test/esiFunctionTest.js
+++ b/test/esiFunctionTest.js
@@ -2,6 +2,7 @@
 
 const ck = require("chronokinesis");
 const localEsi = require("..");
+const toCookieStr = require("./toCookieStr");
 
 describe("functions", () => {
   describe("$add_header", () => {
@@ -11,12 +12,12 @@ describe("functions", () => {
       markup += "</esi:vars>";
 
       const headers = [];
-      function set(name, value) {
-        headers.push({name, value});
+      function cookie(name, value, options) {
+        headers.push({name: "Set-Cookie", value: toCookieStr(name, value, options)});
       }
 
       localEsi(markup, { }, {
-        set,
+        cookie,
         send(body) {
           expect(body).to.equal("");
           expect(headers).to.have.length(1);
@@ -30,23 +31,23 @@ describe("functions", () => {
     it("should set multiple headers when instructed", (done) => {
       let markup = "<esi:vars>";
       markup += "$add_header('Set-Cookie', 'MyCookie1=SomeValue;')";
-      markup += "$add_header('Set-Cookie', 'MyCookie2=SomeValue2; Path=/;Secure;SameSite=Lax')";
+      markup += "$add_header('Set-Cookie', 'MyCookie2=SomeValue2; Path=/; Secure; SameSite=Lax')";
       markup += "</esi:vars>";
 
       const headers = [];
-      function set(name, value) {
-        headers.push({name, value});
+      function cookie(name, value, options) {
+        headers.push({name: "Set-Cookie", value: toCookieStr(name, value, options)});
       }
 
       localEsi(markup, { }, {
-        set,
+        cookie,
         send(body) {
           expect(body).to.equal("");
           expect(headers).to.have.length(2);
           expect(headers[0]).to.have.property("name", "Set-Cookie");
           expect(headers[0]).to.have.property("value", "MyCookie1=SomeValue;");
           expect(headers[1]).to.have.property("name", "Set-Cookie");
-          expect(headers[1]).to.have.property("value", "MyCookie2=SomeValue2; Path=/;Secure;SameSite=Lax");
+          expect(headers[1]).to.have.property("value", "MyCookie2=SomeValue2; Path=/; Secure; SameSite=Lax");
           done();
         }
       }, done);
@@ -56,12 +57,12 @@ describe("functions", () => {
       const markup = "$add_header('Set-Cookie', 'MyCookie1=SomeValue;')";
 
       const headers = [];
-      function set(name, value) {
-        headers.push({name, value});
+      function cookie(name, value, options) {
+        headers.push({name: "Set-Cookie", value: toCookieStr(name, value, options)});
       }
 
       localEsi(markup, { }, {
-        set,
+        cookie,
         send(body) {
           expect(body).to.equal(markup);
           expect(headers).to.have.length(0);
@@ -88,12 +89,12 @@ describe("functions", () => {
       `.replace(/^\s+|\n/gm, "");
 
       const headers = [];
-      function set(name, value) {
-        headers.push({name, value});
+      function cookie(name, value, options) {
+        headers.push({name: "Set-Cookie", value: toCookieStr(name, value, options)});
       }
 
       localEsi(markup, { }, {
-        set,
+        cookie,
         send(body) {
           expect(body).to.equal("");
           expect(headers).to.have.length(2);

--- a/test/toCookieStr.js
+++ b/test/toCookieStr.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = (name, value, attributes) => {
+  return Object.keys(attributes).reduce((acc, key) => {
+    const val = attributes[key];
+    if (val) {
+      return `${acc}; ${key}=${val}`.trim();
+    }
+    return `${acc}; ${key}`.trim();
+  }, `${name}=${value}`);
+};


### PR DESCRIPTION
…y one header and cookie will be set in Express.js

This is needed because in Express.js v4.7.x this code only sets the last cookie.

```
    res.set("set-cookie", "a=1");
    res.set("set-cookie", "b=2");
```

The correct way of doing it is:

```
    res.cookie("a", "1");
    res.cookie("b", "2");
```    
    