### PR TITLE
Support string_split and named item-variable in foreach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support `$string_split`
+- Support named `item` variable in foreach
+
 ## [1.2.6] - 2021-02-16
 ### Changed
 - Change protocol of atlas-html-stream dependency

--- a/lib/ESIEvaluator.js
+++ b/lib/ESIEvaluator.js
@@ -166,9 +166,7 @@ module.exports = function ESIEvaluator(context) {
       if (!Array.isArray(context.items)) {
         context.items = Object.entries(context.items);
       }
-      if (data.item) {
-        context.itemVariableName = data.item;
-      }
+      context.itemVariableName = data.item || "item";
 
       context.foreachChunks = [];
       return next();
@@ -182,7 +180,7 @@ module.exports = function ESIEvaluator(context) {
       context.items.forEach((value) => {
         if (Array.isArray(value)) value = `[${value.map((v) => typeof v === "string" ? `'${v}'` : v).join(",")}]`;
         buffered = buffered.concat([{
-          name: "esi:assign", data: {name: context.itemVariableName || "item", value: value.toString()}
+          name: "esi:assign", data: {name: context.itemVariableName, value: value.toString()}
         }, {name: "esi:assign"}], foreachChunks);
       });
 

--- a/lib/ESIEvaluator.js
+++ b/lib/ESIEvaluator.js
@@ -166,6 +166,9 @@ module.exports = function ESIEvaluator(context) {
       if (!Array.isArray(context.items)) {
         context.items = Object.entries(context.items);
       }
+      if (data.item) {
+        context.itemVariableName = data.item;
+      }
 
       context.foreachChunks = [];
       return next();
@@ -179,7 +182,7 @@ module.exports = function ESIEvaluator(context) {
       context.items.forEach((value) => {
         if (Array.isArray(value)) value = `[${value.map((v) => typeof v === "string" ? `'${v}'` : v).join(",")}]`;
         buffered = buffered.concat([{
-          name: "esi:assign", data: {name: "item", value: value.toString()}
+          name: "esi:assign", data: {name: context.itemVariableName || "item", value: value.toString()}
         }, {name: "esi:assign"}], foreachChunks);
       });
 

--- a/lib/expression/evaluate.js
+++ b/lib/expression/evaluate.js
@@ -67,6 +67,14 @@ module.exports = function evaluate(ast, context) {
       const value = getFunc(arg.type)(arg);
       return (typeof value === "undefined") ? "None" : String(value);
     },
+    string_split([arg1, arg2]) {
+      const stringToSplit = getFunc(arg1.type)(arg1);
+      const splitBy = getFunc(arg2.type)(arg2);
+      if (typeof stringToSplit !== "string" || typeof splitBy !=="string") {
+        throw new Error("string_split requires two arguments of type string");
+      }
+      return stringToSplit.split(splitBy);
+    },
     substr([arg1, arg2, arg3]) {
       const string = getFunc(arg1.type)(arg1);
       if (typeof string !== "string") {

--- a/test/esiFunctionTest.js
+++ b/test/esiFunctionTest.js
@@ -756,15 +756,15 @@ describe("functions", () => {
   describe("supports $string_split", () => {
     it("can split a string by a single character as a separator", (done) => {
       const markup = `
-      <esi:assign name="commaSeparatedString" value="one,two,three"/>
-      <esi:foreach collection="$string_split($(commaSeparatedString), ',')">
-        <p>hello!</p>
+      <esi:assign name="someString" value="one,two,three"/>
+      <esi:foreach collection="$string_split($(someString), ',')">
+        <p>$(item)</p>
       </esi:foreach>
       `.replace(/^\s+|\n/gm, "");
 
       localEsi(markup, { }, {
         send(body) {
-          expect(body).to.equal(`<p>hello!</p><p>hello!</p><p>hello!</p>`);
+          expect(body).to.equal(`<p>one</p><p>two</p><p>three</p>`);
           done();
         }
       }, done);
@@ -772,15 +772,15 @@ describe("functions", () => {
 
     it("can split a string by multiple characters as a separator", (done) => {
       const markup = `
-      <esi:assign name="commaSeparatedString" value="one...two...three"/>
-      <esi:foreach collection="$string_split($(commaSeparatedString), '...')">
-        <p>hello!</p>
+      <esi:assign name="somesString" value="one...two...three"/>
+      <esi:foreach collection="$string_split($(somesString), '...')">
+        <p>$(item)</p>
       </esi:foreach>
       `.replace(/^\s+|\n/gm, "");
 
       localEsi(markup, { }, {
         send(body) {
-          expect(body).to.equal(`<p>hello!</p><p>hello!</p><p>hello!</p>`);
+          expect(body).to.equal(`<p>one</p><p>two</p><p>three</p>`);
           done();
         }
       }, done);

--- a/test/esiFunctionTest.js
+++ b/test/esiFunctionTest.js
@@ -752,4 +752,38 @@ describe("functions", () => {
       }, done);
     });
   });
+
+  describe("supports $string_split", () => {
+    it("can split a string by a single character as a separator", (done) => {
+      const markup = `
+      <esi:assign name="commaSeparatedString" value="one,two,three"/>
+      <esi:foreach collection="$string_split($(commaSeparatedString), ',')">
+        <p>hello!</p>
+      </esi:foreach>
+      `.replace(/^\s+|\n/gm, "");
+
+      localEsi(markup, { }, {
+        send(body) {
+          expect(body).to.equal(`<p>hello!</p><p>hello!</p><p>hello!</p>`);
+          done();
+        }
+      }, done);
+    });
+
+    it("can split a string by multiple characters as a separator", (done) => {
+      const markup = `
+      <esi:assign name="commaSeparatedString" value="one...two...three"/>
+      <esi:foreach collection="$string_split($(commaSeparatedString), '...')">
+        <p>hello!</p>
+      </esi:foreach>
+      `.replace(/^\s+|\n/gm, "");
+
+      localEsi(markup, { }, {
+        send(body) {
+          expect(body).to.equal(`<p>hello!</p><p>hello!</p><p>hello!</p>`);
+          done();
+        }
+      }, done);
+    });
+  });
 });

--- a/test/localEsiTest.js
+++ b/test/localEsiTest.js
@@ -1752,6 +1752,34 @@ describe("local ESI", () => {
         }
       }, done);
     });
+
+    it("can handle named item variables in foreach", (done) => {
+      const markup = `
+        <ul>
+          <esi:foreach item="myItemVariable" collection="[1,2,3]">
+            <esi:vars>
+              <li>$(myItemVariable)</li>
+            </esi:vars>
+          </esi:foreach>
+        </ul>
+        `.replace(/^\s+|\n/gm, "");
+
+      const expectedMarkup = `
+        <ul>
+            <li>1</li>
+            <li>2</li>
+            <li>3</li>
+        </ul>
+      `.replace(/^\s+|\n/gm, "");
+
+      localEsi(markup, {}, {
+        send(body) {
+          expect(body).to.equal(expectedMarkup);
+          done();
+        }
+      }, done);
+    });
+
   });
 
   describe("illegal characters", () => {


### PR DESCRIPTION
This PR does two things

1. supports`$string_split`
2. supports named item variables like `<esi:foreach item="myVariable" collection="myCollection">`


-----


My real-world-use case for this is to stringsplit a cookie and do a foreach that outputs each split segment
```
<esi:assign name="newsletters" value="$(HTTP_COOKIE{'cookieWithCommaSeparatedStrings'})"/>
<esi:foreach item="singleString" collection="$string_split($(cookieWithCommaSeparatedStrings), ',')">
   <esi:vars>$(singleString)</esi:vars>
</esi:foreach>
``` 
