### PR TITLE
Readme sample code header fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ module.exports = function render(req, res, next) {
 
   const {statusCode, headers, body} = await parse(html, options);
   if (statusCode < 309 && statusCode > 300) {
-    return res.redirect(statusCode, location);
+    return res.redirect(statusCode, headers.location);
   }
 
   if (statusCode) {

--- a/README.md
+++ b/README.md
@@ -119,7 +119,12 @@ module.exports = function render(req, res, next) {
     return res.redirect(response.statusCode, headers.location);
   }
 
-  res.status(statusCode || 200);
+  if (statusCode) {
+    res.status(statusCode);
+  } else if (!res.statusCode) {
+    res.status(200);
+  }
+  
   return res.send(body);
 };
 ```

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ module.exports = function render(req, res, next) {
 
   const {statusCode, headers, body} = await parse(html, options);
   if (statusCode < 309 && statusCode > 300) {
-    return res.redirect(response.statusCode, headers.location);
+    return res.redirect(statusCode, location);
   }
 
   if (statusCode) {


### PR DESCRIPTION
Recently upgrades from local-esi v1 to v2, by implementing the `render` function in the README example code for `Example express route` and noticed some problems:

a) `res.status(statusCode || 200);` meant that if `res.statusCode` was anything other than 300 to 309 it would be overwritten to 200. This caused problems if the `res.statusCode` was 404, as an example.

b) This piece of code had a mistake

```
if (statusCode < 309 && statusCode > 300) {
    return res.redirect(response.statusCode, headers.location);
  }  
```

First of all,`response` is undefined. (It should be `res`)

Secondly, we don't wanna use the response statusCode in this context.

We want to use the statusCode that local-esi produced.