### PR TITLE
Proof of concept port to Fastly Compute@Edge

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,9 @@
 {
   "root": true,
-  "extends": ["eslint-config-exp"]
+  "extends": ["eslint-config-exp"],
+  "globals": {
+    "CustomEvent": "readonly",
+    "ReadableStream": "readonly",
+    "TransformStream": "readonly"
+  }
 }

--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module.exports = function streamRender(req, res, next) {
     esi,
     new HTMLWriter(),
   ], (err) => {
-    if (err?.code === "ERR_STREAM_PREMATURE_CLOSE"]) {
+    if (err?.code === "ERR_STREAM_PREMATURE_CLOSE") {
       return;
     } else if (err) {
       return next(err);

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 "use strict";
 
-const { pipeline, Readable } = require("stream");
 const ESI = require("./lib/ESI");
-const HTMLStream = require("@bonniernews/atlas-html-stream");
+const HtmlParser = require("../atlas-html-stream/src/HtmlParser.js");
 const HTMLWriter = require("./lib/HTMLWriter");
 
 module.exports = {
@@ -11,43 +10,64 @@ module.exports = {
   parse,
 };
 
-function parse(html, options) {
+async function parse(html, options) {
+  // console.log("parse options", options);
   const response = {};
 
-  let body = "";
-
-  const esi = new ESI(options)
-    .on("set_response_code", onSetResponseCode)
-    .on("add_header", onAddHeader)
-    .once("set_redirect", onRedirect);
-
-  return new Promise((resolve, reject) => {
-    pipeline([
-      Readable.from(html),
-      new HTMLStream({ preserveWS: true }),
-      esi,
-      new HTMLWriter(),
-    ], (err) => {
-      if (err && ![ "ERR_STREAM_DESTROYED", "ERR_STREAM_PREMATURE_CLOSE" ].includes(err.code)) return reject(err);
-      resolve({
-        body,
-        ...response,
-      });
-    }).on("data", (chunk) => {
-      body += chunk;
-    });
+  const readableStream = new ReadableStream({
+    pull(controller) {
+      controller.enqueue(html);
+      controller.close();
+    },
   });
 
-  function onRedirect(statusCode, location) {
+  const parserTransformer = new HtmlParser({ preserveWS: true });
+  const parserTransformStream = new TransformStream(parserTransformer);
+
+  const esiTransformer = new ESI(options);
+  esiTransformer.addEventListener("set_response_code", onSetResponseCode);
+  esiTransformer.addEventListener("add_header", onAddHeader);
+  esiTransformer.addEventListener("set_redirect", onRedirect);
+  const esiTransformStream = new TransformStream(esiTransformer);
+
+  const writerTransformer = new HTMLWriter();
+  const writerTransformStream = new TransformStream(writerTransformer);
+
+  const transformedStream = readableStream
+    .pipeThrough(parserTransformStream)
+    .pipeThrough(esiTransformStream)
+    .pipeThrough(writerTransformStream);
+
+  const reader = transformedStream.getReader();
+
+  let body = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    body += value;
+  }
+  // console.log("parse returning body: ", body);
+  // console.log("parse returning response: ", response);
+  return { body, ...response };
+
+  function onRedirect(event) {
+    // console.log("in onRedirect function", event);
+    const { statusCode, location } = event.detail;
     response.statusCode = statusCode;
     if (location) {
       response.headers = response.headers || {};
       response.headers.location = location;
     }
-    this.destroy();
+    // this.destroy();
   }
 
-  function onAddHeader(name, value) {
+  function onAddHeader(event) {
+    // console.log("in onAddHeader function", event);
+    const { name, value } = event.detail;
+    // console.log(`in onAddHeader name=${name} value=${value}`);
+
     const headers = response.headers = response.headers || {};
     const lname = name.toLowerCase();
     if (lname === "set-cookie") {
@@ -58,10 +78,14 @@ function parse(html, options) {
     }
   }
 
-  function onSetResponseCode(statusCode, withBody) {
+  function onSetResponseCode(event) {
+    // console.log("in onSetResponseCode function", event);
+
+    const { statusCode, withBody } = event.detail;
+
     response.statusCode = statusCode;
     if (!withBody) return;
     response.body = withBody;
-    this.destroy();
+    // this.destroy();
   }
 }

--- a/lib/ESI.js
+++ b/lib/ESI.js
@@ -6,6 +6,7 @@ const ESIBase = require("./ESIBase");
 
 module.exports = class ESI extends ESIBase {
   constructor(options) {
+    // console.log("ESI constructor");
     const evaluator = new ESIEvaluator(new ListenerContext(options));
     super(evaluator);
     this.context.emitter = this;

--- a/lib/ESIBase.js
+++ b/lib/ESIBase.js
@@ -1,20 +1,23 @@
 "use strict";
 
-const { Transform } = require("stream");
-
-module.exports = class ESIBase extends Transform {
+module.exports = class ESIBase extends EventTarget {
   constructor(evaluator) {
-    super({ objectMode: true });
+    super();
+    // console.log("ESIBase constructor");
     this.evaluator = evaluator;
     this.context = evaluator.context;
   }
-  _transform({ name, data, text }, encoding, next) {
+  transform(chunk, controller) {
+    const { name, data, text } = chunk;
     if (text) {
-      return this.evaluator.ontext(text, next);
+      // console.log(`ESIBase::transform text ${text}`)
+      return this.evaluator.ontext(text, controller);
     } else if (name && data) {
-      return this.evaluator.onopentag(name, data, next);
+      // console.log(`ESIBase::transform onopentag ${name}`, data)
+      return this.evaluator.onopentag(name, data, controller);
     } else {
-      return this.evaluator.onclosetag(name, next);
+      // console.log(`ESIBase::transform onclosetag ${name}`, data)
+      return this.evaluator.onclosetag(name, controller);
     }
   }
 };

--- a/lib/ESIEvaluator.js
+++ b/lib/ESIEvaluator.js
@@ -2,19 +2,16 @@
 "use strict";
 
 const { assign, test, replace } = require("./evaluateExpression");
-const { pipeline, Readable } = require("stream");
 const ESIBase = require("./ESIBase");
-const HTMLStream = require("@bonniernews/atlas-html-stream");
+const HtmlParser = require("../../atlas-html-stream/src/HtmlParser.js");
 
 class ESITag {
   constructor(context) {
     this.context = context;
   }
-  open(data, next) {
-    next();
+  open(data, controller) {
   }
-  close(next) {
-    next();
+  close(controller) {
   }
 }
 
@@ -29,12 +26,12 @@ class ESITry extends ESITag {
       throw new Error(`${name} is not allowed inside an esi:try`);
     }
   }
-  close(next) {
+  close(controller) {
     if (!this.children.includes("esi:attempt")) {
-      return next(new Error("esi:try without esi:attempt not allowed"));
+      controller.error(new Error("esi:try without esi:attempt not allowed"));
+      return;
     }
     this.children.length = 0;
-    next();
   }
 }
 
@@ -44,9 +41,8 @@ class ESIAttempt extends ESITag {
       throw new Error("esi:attempt is not allowed outside esi:try");
     }
   }
-  open(data, next) {
+  open(data, controller) {
     this.context.inAttempt = true;
-    next();
   }
 }
 
@@ -56,13 +52,11 @@ class ESIExcept extends ESITag {
       throw new Error("esi:except is not allowed outside esi:try");
     }
   }
-  open(data, next) {
+  open(data, controller) {
     this.context.inExcept = true;
-    next();
   }
-  close(next) {
+  close(controller) {
     this.context.inExcept = false;
-    next();
   }
 }
 
@@ -77,17 +71,17 @@ class ESIChoose extends ESITag {
       throw new Error(`${name} is not allowed inside a esi:choose`);
     }
   }
-  open(data, next) {
+  open(data, controller) {
     this.context.chooses.push({ testMatched: false, chosen: false });
-    return next();
   }
-  close(next) {
+  close(controller) {
     if (!this.children.includes("esi:when")) {
-      return next(new Error("esi:choose without esi:when not allowed"));
+      controller.error(new Error("esi:choose without esi:when not allowed"));
+      return;
     }
     this.children.length = 0;
     this.context.chooses.pop();
-    return next();
+    return;
   }
 }
 
@@ -97,7 +91,7 @@ class ESIWhen extends ESITag {
       throw new Error("esi:when is not allowed outside esi:choose");
     }
   }
-  open(data, next) {
+  open(data, controller) {
     const context = this.context;
     const lastChoose = context.chooses[context.chooses.length - 1];
 
@@ -105,12 +99,13 @@ class ESIWhen extends ESITag {
     try {
       result = test(data.test, context);
     } catch (err) {
-      return next(err);
+      controller.error(err);
+      return;
     }
 
     if (lastChoose.testMatched) {
       lastChoose.chosen = false;
-      return next();
+      return;
     }
 
     if (data.matchname) {
@@ -119,7 +114,7 @@ class ESIWhen extends ESITag {
 
     lastChoose.testMatched = lastChoose.chosen = !!result;
 
-    return next();
+    return;
   }
 }
 
@@ -129,11 +124,11 @@ class ESIOtherwise extends ESITag {
       throw new Error("esi:otherwise is not allowed outside esi:choose");
     }
   }
-  open(data, next) {
+  open(data, controller) {
     const context = this.context;
     const lastChoose = context.chooses[context.chooses.length - 1];
     lastChoose.chosen = !lastChoose.testMatched;
-    return next();
+    return;
   }
 }
 
@@ -144,78 +139,156 @@ class ESIText extends ESITag {
 }
 
 class ESIAssign extends ESITag {
-  open(data, next) {
+  open(data, controller) {
     const context = this.context;
     if (!context.shouldWrite()) {
-      return next();
+      return;
     }
 
     const value = data.value;
     try {
       context.assigns[data.name] = assign(value, context);
     } catch (err) {
-      if (/unknown keyword/i.test(err.message)) context.assigns[data.name] = value;
-      else return next(err);
+      if (/unknown keyword/i.test(err.message)) {
+        context.assigns[data.name] = value;
+      } else {
+        controller.error(err);
+        return;
+      }
     }
-
-    next();
   }
 }
 
 class ESIBreak extends ESITag {
-  open(data, next) {
+  open(data, controller) {
     const context = this.context;
-    if (!context.inForeach) return next(new Error("esi:break outside esi:foreach"));
+    if (!context.inForeach) {
+      controller.error(new Error("esi:choose without esi:when not allowed"));
+      return;
+    }
     context.breakHit = context.breakHit || context.shouldWrite();
-    return context.breakHit ? next(null, { name: "esi:break" }) : next();
+    if (context.breakHit) {
+      controller.enqueue({ name: "esi:break" });
+    }
   }
 }
 
 class ESIEval extends ESITag {
-  open(data, next) {
+  async open(data, controller) {
+    // console.log('ESIEval', data);
     const context = this.context;
-    if (!context.shouldWrite()) return next();
+    if (!context.shouldWrite()) return;
 
-    const chunks = [];
-    pipeline([
-      context.fetch(data),
-      new HTMLStream({ preserveWS: true }),
-      new ESIBase(new ESIEvaluator(context.clone(true))),
-    ], (err) => {
-      if (err) {
-        if (err.inAttempt) return next();
-        return next(err);
+    const readableStream = await context.fetch(data);
+    // console.log("ESIEval readableStream", readableStream);
+
+    if (!readableStream) {
+      // controller.error("No response");
+      return;
+    }
+
+    // const textDecoderStream = new TextDecoderStream();
+    let decoder = new TextDecoder();
+    const textDecoderStream = new TransformStream({
+      transform(chunk, controller) {
+        // console.log("in decodeTransform", chunk);
+        controller.enqueue(decoder.decode(chunk));
+      },
+    });
+
+    const parserTransformer = new HtmlParser({ preserveWS: true });
+    const parserTransformStream = new TransformStream(parserTransformer);
+
+    const esiTransformer = new ESIBase(new ESIEvaluator(context.clone(true)));
+    const esiTransformStream = new TransformStream(esiTransformer);
+
+    const transformedStream = readableStream
+      .pipeThrough(textDecoderStream)
+      .pipeThrough(parserTransformStream)
+      .pipeThrough(esiTransformStream);
+
+    const reader = transformedStream.getReader();
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
       }
-      return context.writeToResult(chunks, next);
-    }).on("data", (chunk) => chunks.push(chunk));
+      controller.enqueue(value);
+    }
+    // const chunks = [];
+    // pipeline([
+    //   context.fetch(data),
+    //   new HTMLStream({ preserveWS: true }),
+    //   new ESIBase(new ESIEvaluator(context.clone(true))),
+    // ], (err) => {
+    //   if (err) {
+    //     if (err.inAttempt) return next();
+    //     return next(err);
+    //   }
+    //   return context.writeToResult(chunks, controller);
+    // }).on("data", (chunk) => chunks.push(chunk));
   }
 }
 
 class ESIInclude extends ESITag {
-  open(data, next) {
+  async open(data, controller) {
+    // console.log('ESIInclude', data);
     const context = this.context;
-    if (!context.shouldWrite()) return next();
+    if (!context.shouldWrite()) return;
 
-    const chunks = [];
-    const streams = [
-      context.fetch(data),
-      new HTMLStream({ preserveWS: true }),
-    ];
-    if (data.dca === "esi") {
-      streams.push(new ESIBase(new ESIEvaluator(context.clone())));
-    }
-    pipeline(streams, (err) => {
-      if (err) {
-        if (err.inAttempt) return next();
-        return next(err);
+    const readableStream = await context.fetch(data);
+    // console.log("ESIEval readableStream", readableStream);
+
+    // const textDecoderStream = new TextDecoderStream();
+    let decoder = new TextDecoder();
+    const textDecoderStream = new TransformStream({
+      transform(chunk, controller) {
+        controller.enqueue(decoder.decode(chunk));
+      },
+    });
+
+    const parserTransformer = new HtmlParser({ preserveWS: true });
+    const parserTransformStream = new TransformStream(parserTransformer);
+
+    const esiTransformer = new ESIBase(new ESIEvaluator(context.clone()));
+    const esiTransformStream = new TransformStream(esiTransformer);
+
+    const transformedStream = readableStream
+      .pipeThrough(textDecoderStream)
+      .pipeThrough(parserTransformStream)
+      .pipeThrough(esiTransformStream);
+
+    const reader = transformedStream.getReader();
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
       }
-      return context.writeToResult(chunks, next);
-    }).on("data", (chunk) => chunks.push(chunk));
+      controller.enqueue(value);
+    }
+  //   const chunks = [];
+  //   const streams = [
+  //     context.fetch(data),
+  //     new HTMLStream({ preserveWS: true }),
+  //   ];
+  //   if (data.dca === "esi") {
+  //     streams.push(new ESIBase(new ESIEvaluator(context.clone())));
+  //   }
+  //   pipeline(streams, (err) => {
+  //     if (err) {
+  //       if (err.inAttempt) return;
+  //       controller.error(err);
+  //       return;
+  //     }
+  //     return context.writeToResult(chunks, controller);
+  //   }).on("data", (chunk) => chunks.push(chunk));
   }
 }
 
 class ESIForEach extends ESITag {
-  open(data, next) {
+  open(data, controller) {
     const context = this.context;
     context.items = assign(data.collection, context);
     if (!Array.isArray(context.items)) {
@@ -224,9 +297,9 @@ class ESIForEach extends ESITag {
     context.itemVariableName = data.item || "item";
 
     context.foreachChunks = [];
-    return next();
+    return;
   }
-  close(next) {
+  async close(controller) {
     const context = this.context;
     const foreachChunks = context.foreachChunks;
     delete context.foreachChunks;
@@ -243,20 +316,51 @@ class ESIForEach extends ESITag {
     localContext.inForeach = true;
     const chunks = [];
 
-    pipeline([
-      Readable.from(buffered),
-      new ESIBase(new ESIEvaluator(localContext)),
-    ], (err) => {
-      if (err) return next(err);
-      return context.writeToResult(chunks, next);
-    }).on("data", function onData(chunk) {
-      if (chunk.name === "esi:break") {
-        this.pause();
-        return process.nextTick(() => this.push(null));
-      }
-
-      chunks.push(chunk);
+    // console.log("buffered", buffered);
+    const readableStream = new ReadableStream({
+      pull(c) {
+        buffered.forEach((chunk) => {
+          c.enqueue(chunk);
+        });
+        c.close();
+      },
     });
+
+    const esiTransformer = new ESIBase(new ESIEvaluator(localContext));
+    const esiTransformStream = new TransformStream(esiTransformer);
+
+    const transformedStream = readableStream
+      .pipeThrough(esiTransformStream);
+    const reader = transformedStream.getReader();
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value.name === "esi:break") {
+        // console.log("esi break?");
+        this.pause();
+        // controller.enqueue(null);
+        return;
+      }
+      controller.enqueue(value);
+    }
+
+    // pipeline([
+    //   Readable.from(buffered),
+    //   new ESIBase(new ESIEvaluator(localContext)),
+    // ], (err) => {
+    //   if (err) return next(err);
+    //   return context.writeToResult(chunks, controller);
+    // }).on("data", function onData(chunk) {
+    //   if (chunk.name === "esi:break") {
+    //     this.pause();
+    //     return process.nextTick(() => this.push(null));
+    //   }
+
+    //   chunks.push(chunk);
+    // });
   }
 }
 
@@ -280,11 +384,14 @@ class ESIEvaluator {
   constructor(context) {
     this.context = context;
   }
-  onopentag(name, data, next) {
+  onopentag(name, data, controller) {
+    // console.log(`ESIEvaluator open ${name}`);
+    // console.log("ESIEvaluator open enqueueing text onopentag");
+    // controller.enqueue({ text: "onopentag" });
     const context = this.context;
     if (context.foreachChunks) {
       context.foreachChunks.push({ name, data });
-      return next();
+      return;
     }
 
     if (name.startsWith("esi:")) {
@@ -302,48 +409,54 @@ class ESIEvaluator {
         try {
           parent.assertChild(name);
         } catch (err) {
-          return next(err);
+          controller.error(err);
+          return;
         }
       }
       if (esiFunc?.assertParent) {
         try {
           esiFunc.assertParent(parent);
         } catch (err) {
-          return next(err);
+          controller.error(err);
+          return;
         }
       }
-      if (!wasInPlainText) return esiFunc.open(data, next);
+      if (!wasInPlainText) return esiFunc.open(data, controller);
     }
 
-    context.writeToResult({ name, data: this.makeAttributes(data) }, next);
+    // console.log(`ESIEvaluator open writeToResult ${name}`);
+    context.writeToResult({ name, data: this.makeAttributes(data) }, controller);
   }
-  onclosetag(name, next) {
+  onclosetag(name, controller) {
+    // console.log(`ESIEvaluator close ${name}`);
     const context = this.context;
     if (name !== "esi:foreach" && context.foreachChunks) {
       context.foreachChunks.push({ name });
-      return next();
+      return;
     }
 
     if (name.startsWith("esi:")) {
       const popped = context.tags.pop();
 
       if (!context.isInPlainText()) {
-        if (popped && popped.close) return popped.close(next);
-        return next();
+        if (popped && popped.close) return popped.close(controller);
+        return;
       }
     }
 
-    context.writeToResult({ name }, next);
+    context.writeToResult({ name }, controller);
   }
-  ontext(text, next) {
+  ontext(text, controller) {
+    // console.log(`ESIEvaluator ontext ${text}`);
+
     const context = this.context;
     if (context.foreachChunks) {
       context.foreachChunks.push({ text });
-      return next();
+      return;
     }
 
     if (!context.isProcessing()) {
-      return context.writeToResult({ text }, next);
+      return context.writeToResult({ text }, controller);
     }
 
     const current = context.tags[context.tags.length - 1];
@@ -356,15 +469,18 @@ class ESIEvaluator {
         const result = { text: replace(text, currentContext || context) };
         context.bufferingString = false;
         return result;
-      }, next); // handleProcessingInstructions may cause an (expected) error and we're not sure writeToResult will actually write so we pass a function that it can call if it should write
+      }, controller); // handleProcessingInstructions may cause an (expected) error and we're not sure writeToResult will actually write so we pass a function that it can call if it should write
     } catch (err) {
       if (err.message.includes("Found end of file before end")) {
         context.bufferingString = true;
         current.text = text;
-        return next();
+        return;
+      } else {
+        controller.error(err);
+        return;
       }
 
-      return next(err);
+      return;
     }
   }
   makeAttributes(data) {

--- a/lib/HTMLWriter.js
+++ b/lib/HTMLWriter.js
@@ -1,19 +1,15 @@
 "use strict";
 
 const { chunkToMarkup } = require("./markup");
-const { Transform } = require("stream");
 
-module.exports = class HTMLWriter extends Transform {
-  constructor() {
-    super({ writableObjectMode: true });
-  }
-  _transform(chunks, encoding, next) {
+module.exports = class HTMLWriter {
+  transform(chunks, controller) {
     if (!chunks) return next();
     chunks = Array.isArray(chunks) ? chunks : [ chunks ];
     let markup = "";
     for (const chunk of chunks) {
       markup += chunkToMarkup(chunk);
     }
-    return next(null, markup);
+    controller.enqueue(markup);
   }
 };

--- a/lib/ListenerContext.js
+++ b/lib/ListenerContext.js
@@ -1,14 +1,12 @@
 "use strict";
 
 const { chunkToMarkup } = require("./markup");
-const { EventEmitter } = require("events");
 const { replace } = require("./evaluateExpression");
-const request = require("got");
 
 module.exports = class ListenerContext {
   constructor(options = {}, emitter) {
     this.options = options;
-    this.emitter = emitter || new EventEmitter();
+    this.emitter = emitter || new EventTarget();
     this.inAttempt = false;
     this.lastAttemptWasError = false;
     this.inExcept = false;
@@ -53,8 +51,10 @@ module.exports = class ListenerContext {
 
     return true;
   }
-  writeToResult(chunk, next) {
+  writeToResult(chunk, controller) {
+    // console.log("writeToResult chunk", chunk);
     if (this.bufferingString) {
+      // console.log("writeToResult bufferingString");
       const [ current = {} ] = this.tags.slice(-1);
       if (typeof chunk === "function") {
         chunk = chunk();
@@ -62,29 +62,36 @@ module.exports = class ListenerContext {
 
       current.text += chunkToMarkup(chunk);
 
-      return next();
+      // return next();
+      return;
     }
 
     if (this.shouldWrite()) {
+      // console.log("writeToResult shouldWrite", chunk);
       if (typeof chunk === "function") {
         chunk = chunk();
-      }
-      return next(null, chunk);
-    }
+        // console.log("writeToResult shouldWrite function", chunk);
 
-    next();
+      }
+      // console.log("writeToResult enqueue chunk", chunk);
+      controller.enqueue(chunk);
+    }
   }
-  fetch(data) {
+  async fetch(data) {
+    // console.log("fetch", data);
     const self = this;
+    // const cacheOverride = new CacheOverride("override", { ttl: 60 });
+
     const options = {
-      throwHttpErrors: false,
       method: "GET",
-      retry: 0,
       headers: {
         ...self.options.headers,
-        host: undefined,
-        "content-type": undefined,
+        "secret-header": "secret-value",
+        host: "www.example.com",
+      //   "content-type": undefined,
       },
+      backend: "origin",
+      // cacheOverride,
     };
 
     let fetchUrl = replace(data.src, self);
@@ -93,20 +100,40 @@ module.exports = class ListenerContext {
       fetchUrl = new URL(fetchUrl, `http://${host}`).toString();
     }
 
-    return request.stream(fetchUrl, options)
-      .on("response", function onResponse(resp) {
-        if (resp.statusCode < 400) return;
-        if (self.inAttempt) {
-          self.lastAttemptWasError = true;
-          return this.push(null);
-        }
-        return this.destroy(new request.HTTPError(resp));
-      })
-      .on("error", (err) => {
-        if (!self.inAttempt) return;
+    // When running locally
+    fetchUrl = fetchUrl.replace(
+      "http://localhost:7676/",
+      "https://www.example.com/"
+    );
+
+    // console.log("fetch", fetchUrl, options);
+    const response = await fetch(fetchUrl, options);
+    // console.log("fetch status", response.status);
+    if (response.status >= 400) {
+      if (self.inAttempt) {
         self.lastAttemptWasError = true;
-        err.inAttempt = true;
-      });
+        // return this.push(null);
+        return;
+      }
+      // return this.destroy(new request.HTTPError(resp));
+      return;
+    }
+    return response.body;
+
+  //   return fetch(fetchUrl, options)
+  //     .on("response", function onResponse(resp) {
+  //       if (resp.statusCode < 400) return;
+  //       if (self.inAttempt) {
+  //         self.lastAttemptWasError = true;
+  //         return this.push(null);
+  //       }
+  //       return this.destroy(new request.HTTPError(resp));
+  //     })
+  //     .on("error", (err) => {
+  //       if (!self.inAttempt) return;
+  //       self.lastAttemptWasError = true;
+  //       err.inAttempt = true;
+  //     });
   }
 };
 

--- a/lib/expression/evaluate.js
+++ b/lib/expression/evaluate.js
@@ -1,8 +1,13 @@
 /* eslint-disable camelcase */
 "use strict";
+const CryptoJS = require("crypto-js");
 
-const crypto = require("crypto");
-const ent = require("ent");
+class CustomEvent extends Event {
+  constructor(event, { detail }) {
+    super(event);
+    this.detail = detail;
+  }
+}
 
 class Evaluator {
   constructor(context) {
@@ -31,25 +36,41 @@ class Evaluator {
     }
     return Buffer.from(string, "utf8").toString("base64");
   }
-  html_decode([ arg ]) {
-    const string = this.execute(arg.type, arg);
-    if (!string) return "";
-
-    return ent.decode(string);
-  }
   digest_md5([ arg ]) {
     const string = this.execute(arg.type, arg);
+    // console.log(`digest_md5("${string}")`);
     if (!string) {
       return [];
     }
 
-    const md5 = crypto.createHash("md5").update(string).digest();
-    const esihash = [];
-    for (let offset = 0; offset < 16; offset += 4) {
-      esihash.push(md5.readInt32LE(offset));
-    }
+    // const crypto = require("crypto");
+    // const md5 = crypto.createHash("md5").update(string).digest();
+    // console.log("md5", md5);
+    // md5 <Buffer c6 8a 36 27 2a 71 4f 29 7a 4a be a5 15 82 a8 06>
+    // const esihash = [];
+    // for (let offset = 0; offset < 16; offset += 4) {
+    //   esihash.push(md5.readInt32LE(offset));
+    // }
+    // return esihash;
 
+    /* eslint-disable-next-line new-cap */
+    const md5 = CryptoJS.MD5(string);
+    // console.log("md5", md5);
+    const esihash = [
+      swap_endianness(md5.words[0]),
+      swap_endianness(md5.words[1]),
+      swap_endianness(md5.words[2]),
+      swap_endianness(md5.words[3]),
+    ];
+    // console.log("esihash", esihash);
     return esihash;
+    // CrytoJS is big-endian, but we want little-endian
+    function swap_endianness(int) {
+      return ((int & 0xFF) << 24)
+             | ((int & 0xFF00) << 8)
+             | ((int >> 8) & 0xFF00)
+             | ((int >> 24) & 0xFF);
+    }
   }
   url_encode([ arg ]) {
     const string = this.execute(arg.type, arg);
@@ -59,18 +80,57 @@ class Evaluator {
     return encodeURIComponent(string);
   }
   add_header([ name, value ]) {
-    this.context.emitter.emit("add_header", this.execute(name.type, name), this.execute(value.type, value));
+    // console.log(`in evaluate add_header name=${this.execute(name.type, name)} value=${this.execute(value.type, value)}`);
+    // console.log("in evaluate add_header this.context.emitter=", this.context.emitter);
+    // console.log("in evaluate add_header about to call dispatchEvent");
+    this.context.emitter.dispatchEvent(
+      new CustomEvent(
+        "add_header",
+        {
+          detail: {
+            name: this.execute(name.type, name),
+            value: this.execute(value.type, value),
+          },
+        }
+      )
+    );
+    // console.log("in evaluate add_header called dispatchEvent");
   }
   set_redirect([ location ]) {
-    this.context.emitter.emit("set_redirect", 302, this.execute(location.type, location));
+    this.context.emitter.dispatchEvent(
+      new CustomEvent(
+        "set_redirect",
+        {
+          detail: {
+            statusCode: 302,
+            location: this.execute(location.type, location),
+          },
+        }
+      )
+    );
     this.context.redirected = true;
   }
   set_response_code([ code, body ]) {
     if (body) {
-      return this.context.emitter.emit("set_response_code", this.execute(code.type, code), this.execute(body.type, body));
+      return this.context.emitter.dispatchEvent(
+        new CustomEvent(
+          "set_response_code",
+          {
+            detail: {
+              statusCode: this.execute(code.type, code),
+              withBody: this.execute(body.type, body),
+            },
+          }
+        )
+      );
     }
 
-    this.context.emitter.emit("set_response_code", this.execute(code.type, code));
+    this.context.emitter.dispatchEvent(
+      new CustomEvent(
+        "set_response_code",
+        { detail: { statusCode: this.execute(code.type, code) } }
+      )
+    );
   }
   str([ arg ]) {
     const value = this.execute(arg.type, arg);
@@ -86,7 +146,9 @@ class Evaluator {
   }
   substr([ arg1, arg2, arg3 ]) {
     const string = this.execute(arg1.type, arg1);
+    // console.log("substr typeof string", typeof string);
     if (typeof string !== "string") {
+      // console.log("substr invoked on non-string!!!");
       throw new Error("substr invoked on non-string");
     }
     let startIndex;

--- a/lib/expression/lexer.js
+++ b/lib/expression/lexer.js
@@ -41,6 +41,7 @@ class EsiSyntaxError extends SyntaxError {
     super(message);
     this.columnNumber = column;
     this.source = source;
+    // console.error(message, source, column);
     Error.captureStackTrace(this, EsiSyntaxError);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/local-esi",
-  "version": "2.4.0",
+  "version": "2.3.1",
   "description": "Local Edge Side Includes parser",
   "main": "index.js",
   "scripts": {
@@ -14,21 +14,19 @@
   "author": "Bonnier News",
   "license": "MIT",
   "peerDependencies": {
-    "@bonniernews/atlas-html-stream": ">=2",
-    "got": ">=11"
+    "@bonniernews/atlas-html-stream": "file://../fastly-atlas-html-stream"
   },
   "devDependencies": {
-    "@bonniernews/atlas-html-stream": "^2.0.1",
+    "@bonniernews/atlas-html-stream": "file://../fastly-atlas-html-stream",
     "chai": "^4.3.6",
     "chronokinesis": "^3.1.2",
     "eslint": "^8.23.1",
     "eslint-config-exp": "^0.1.1",
-    "got": "^11.8.5",
     "mocha": "^10.0.0",
     "nock": "^13.2.9"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18.7"
   },
   "repository": {
     "type": "git",
@@ -47,6 +45,6 @@
     "test": "test"
   },
   "dependencies": {
-    "ent": "^2.2.0"
+    "crypto-js": "^4.1.1"
   }
 }


### PR DESCRIPTION
This change is a proof of concept port to Fastly Compute@Edge.

It uses:
  * Service Worker rather than Express
  * Streams Standard rather than node:stream
  * Fetch Standard rather than Got
  * EventTarget and CustomEvent rather than EventEmitter
  * Crypto.js rather than node:crypto

The code has a number of limitations:

* The performance has not been evaluated.
* It does not contain an example.
* It includes internal debugging.
* It requires a custom version of atlas-html-stream
* The host name and any extra HTTP headers have to be hard-coded into the source code.

Do not merge.